### PR TITLE
Wires-X isn't always restarted

### DIFF
--- a/AutoRestartWiresX.ahk
+++ b/AutoRestartWiresX.ahk
@@ -46,6 +46,7 @@ Loop {
   WinWait, %wiresxMsgboxTitle% ahk_exe %exeName%,%wiresxMsgboxTriggerText%
 
   logWiresxRestartRequest()
+  WinActivate, %wiresxMsgboxTitle% ahk_exe %exeName%,%wiresxMsgboxTriggerText%
   SendInput {Space}
   infiniteLoopBreaker()
 }


### PR DESCRIPTION
Fixes #7 under the following circumstances:

1. Pop-up is present when script starts, but the window isn't active.
2. Pop-up appears and focus is immediately lost, e.g. via Alt-Tab.

Note: This fix uses WinActivate, as that should be sufficient for a modal
window. If this fails with a real WIRES-X install then WinActivateBottom
may be required.