### PR TITLE
Log file rollover

### DIFF
--- a/AutoRestartWiresX.ahk
+++ b/AutoRestartWiresX.ahk
@@ -72,6 +72,23 @@ infiniteLoopBreaker() {
   Sleep, 15000 ; Back stop, in case of misconfiguration.
 }
 
+getLogFileName() {
+  global logFile
+  global logNamePrefixTimeStampFmt
+
+  if ( logFile != "*" ) {
+    SplitPath, logFile, logFileName, logDir,,,
+    if !FileExist( logDir ) {
+      FileCreateDir, %logDir%
+    }
+    FormatTime, timeStamp,, %logNamePrefixTimeStampFmt%
+    rollingLogFileName := logDir . "\" timeStamp . "_" . logFileName
+  } else {
+    rollingLogFileName = "*"
+  }
+  return rollingLogFileName
+}
+
 logSystemDetails() {
   if ( A_Is64bitOS ) {
     osWordSize = 64
@@ -141,5 +158,6 @@ logMessage( message ) {
   global timeStampFmt
   FormatTime, now,, %timeStampFmt%
   outMessage := now . " " . message . "`n"
-  FileAppend, % outMessage, %logFile%
+  logFilePath := getLogFileName()
+  FileAppend, % outMessage, %logFilePath%   ; 
 }

--- a/Config.ahk
+++ b/Config.ahk
@@ -25,11 +25,12 @@
 minTimeBetweenRestartsMins := 0.25
 exeName = Wires-X.exe
 
-logFile := A_ScriptDir "\AutoRestartWiresX.log"
+logFile := A_ScriptDir "\logs\AutoRestartWiresX.log"
 ;logFile := "*" ; Uncomment to use console logging, instead of log files
 
 ; Localisation
-timeStampFmt = yyyy-MM-dd HH:mm:ss
+logNamePrefixTimeStampFmt = yyyy-MM-dd
+timeStampFmt              = %logNamePrefixTimeStampFmt% HH:mm:ss
 
 ; Wires-X Localisation
 wiresxMsgboxTitle = Warning


### PR DESCRIPTION
Fixes #14

- Log files location now default to the logs sub-folder of the script folder
- The logs folder is created as required
- Log file names are prefixed with the current date
- When a message is logged a new log file is created if required, i.e. on change of date
- This behaviour is configurable via the following variables in Config.ahk:
  - logNamePrefixTimeStampFmt
  - logFile
